### PR TITLE
chore: filter offers by type, denom and fiat

### DIFF
--- a/app/src/network/cosmos/CosmosChain.ts
+++ b/app/src/network/cosmos/CosmosChain.ts
@@ -112,6 +112,8 @@ export class CosmosChain implements Chain {
         const response = await this.cwClient.queryContractSmart(
           this.hubInfo.hubConfig.offer_addr,
           {
+            // TODO: update this query when new contracts are deployed
+            // offers: {
             offers_query: {
               owner: this.getWalletAddress(),
               limit: 10,
@@ -132,22 +134,36 @@ export class CosmosChain implements Chain {
 
   async fetchOffers(args: FetchOffersArgs) {
     console.log('args >>> ', args)
-    // TODO fix init
+    // TODO: fix init
     if (!this.cwClient)
       await this.init()
     try {
+      // TODO: update this query when new contracts are deployed
+      // const queryMsg = {
+      //   offers_by: {
+      //     fiat_currency: args.fiatCurrency,
+      //     offer_type: args.offerType,
+      //     denom: args.denom,
+      //     // min: "",
+      //     // max: "",
+      //     limit: 10,
+      //     order: 'asc',
+      //   },
+      // }
+      const queryMsg = {
+        offers_by_type_fiat: {
+          fiat_currency: args.fiatCurrency,
+          offer_type: args.offerType,
+          // min: "",
+          // max: "",
+          limit: 10,
+          order: 'asc',
+        },
+      }
       const response = await this.cwClient!.queryContractSmart(
         this.hubInfo.hubConfig.offer_addr,
-        {
-          offers_by_type_fiat: {
-            fiat_currency: args.fiatCurrency,
-            offer_type: args.offerType,
-            // min: "",
-            // max: "",
-            limit: 10,
-            order: 'asc',
-          },
-        }) as GetOffer[]
+        queryMsg
+      ) as GetOffer[]
       console.log('response >>> ', response)
       return response
     }

--- a/app/src/stores/client.ts
+++ b/app/src/stores/client.ts
@@ -55,10 +55,10 @@ export const useClientStore = defineStore({
         alert((e as ChainError).message)
       }
     },
-    async fetchOffers({ fiatCurrency, offerType }: FetchOffersArgs) {
+    async fetchOffers(offersArgs: FetchOffersArgs) {
       this.offers = ListResult.loading()
       try {
-        const listOffers = await this.client.fetchOffers({ fiatCurrency, offerType })
+        const listOffers = await this.client.fetchOffers(offersArgs)
         this.offers = ListResult.success(listOffers)
       } catch (e) {
         this.offers = ListResult.error(e as ChainError)

--- a/app/src/types/components.interface.ts
+++ b/app/src/types/components.interface.ts
@@ -67,6 +67,7 @@ export enum OfferState { active = 'active', paused = 'paused', archived = 'archi
 export interface FetchOffersArgs {
   fiatCurrency: FiatCurrency
   offerType: OfferType
+  denom: Denom
 }
 
 export interface NewTrade {

--- a/app/src/ui/components/offers/ListOffers.vue
+++ b/app/src/ui/components/offers/ListOffers.vue
@@ -38,28 +38,23 @@ function unselectOffer(offer: ExpandableItem<GetOffer>) {
   offer.isExpanded = false
 }
 
+async function fetchOffers() {
+  await client.fetchOffers({
+    fiatCurrency: fiatCurrency.value,
+    offerType: offerType.value,
+    denom: { native: selectedCrypto.value },
+  })
+}
+
 onMounted(async () => {
   await priceStore.fetchPrices()
-  // TODO we should send the selectedCrypto here to filter on fetchOffers
-  await client.fetchOffers({
-    fiatCurrency: fiatCurrency.value,
-    offerType: offerType.value,
-  })
+  await fetchOffers()
 })
 
-watch(fiatCurrency, async () => {
-  await client.fetchOffers({
-    fiatCurrency: fiatCurrency.value,
-    offerType: offerType.value,
-  })
-})
+watch(fiatCurrency, async () => await fetchOffers())
+watch(selectedCrypto, async () => await fetchOffers())
+watch(offerType, async () => await fetchOffers())
 
-watch(offerType, async () => {
-  await client.fetchOffers({
-    fiatCurrency: fiatCurrency.value,
-    offerType: offerType.value,
-  })
-})
 </script>
 
 <template>

--- a/contracts/contracts/offer/src/contract.rs
+++ b/contracts/contracts/offer/src/contract.rs
@@ -65,50 +65,39 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::HubAddr {} => to_binary(&query_hub_addr(deps)?),
         QueryMsg::State {} => to_binary(&query_state(deps)?),
-        QueryMsg::Offers { fiat_currency } => {
-            to_binary(&OfferModel::query_all_offers(deps.storage, fiat_currency)?)
-        }
-        QueryMsg::OffersQuery {
+        QueryMsg::Offer { id } => to_binary(&load_offer_by_id(deps.storage, id)?),
+        QueryMsg::Offers {
             owner,
             min,
             max,
             limit,
             order,
-        } => to_binary(&OfferModel::query(deps, owner, min, max, limit, order)?),
-        QueryMsg::OffersByType {
-            offer_type,
-            last_value,
-            limit,
-        } => to_binary(&OfferModel::query_by_type(
-            deps, offer_type, last_value, limit,
-        )?),
-        QueryMsg::OffersByFiat {
-            fiat_currency,
-            last_value,
-            limit,
-        } => to_binary(&OfferModel::query_by_fiat(
-            deps,
-            fiat_currency,
-            last_value,
-            limit,
-        )?),
-        QueryMsg::OffersByTypeFiat {
-            offer_type,
-            fiat_currency,
-            min,
-            max,
-            limit,
-            order,
-        } => to_binary(&OfferModel::query_by_type_fiat(
-            deps,
-            offer_type,
-            fiat_currency,
+        } => to_binary(&OfferModel::query(
+            deps.storage,
+            owner,
             min,
             max,
             limit,
             order,
         )?),
-        QueryMsg::Offer { id } => to_binary(&load_offer_by_id(deps.storage, id)?),
+        QueryMsg::OffersBy {
+            offer_type,
+            fiat_currency,
+            denom,
+            min,
+            max,
+            limit,
+            order,
+        } => to_binary(&OfferModel::query_by(
+            deps.storage,
+            offer_type,
+            fiat_currency,
+            denom,
+            min,
+            max,
+            order,
+            limit,
+        )?),
         QueryMsg::Arbitrator { arbitrator } => to_binary(&query_arbitrator(deps, arbitrator)?),
         QueryMsg::Arbitrators { last_value, limit } => {
             to_binary(&query_arbitrators(deps, last_value, limit)?)

--- a/contracts/contracts/offer/src/contract.rs
+++ b/contracts/contracts/offer/src/contract.rs
@@ -72,14 +72,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             max,
             limit,
             order,
-        } => to_binary(&OfferModel::query(
-            deps.storage,
-            owner,
-            min,
-            max,
-            limit,
-            order,
-        )?),
+        } => to_binary(&OfferModel::query(deps, owner, min, max, limit, order)?),
         QueryMsg::OffersBy {
             offer_type,
             fiat_currency,

--- a/contracts/packages/protocol/src/offer.rs
+++ b/contracts/packages/protocol/src/offer.rs
@@ -1,6 +1,7 @@
 use super::constants::OFFERS_KEY;
 use crate::currencies::FiatCurrency;
 // use crate::errors::GuardError;
+use crate::denom_utils::denom_to_string;
 use crate::trade::{Trade, TradeState};
 use cosmwasm_std::{
     to_binary, Addr, Deps, Order, QuerierWrapper, QueryRequest, StdResult, Storage, Uint128,
@@ -14,19 +15,16 @@ use std::fmt::{self};
 use std::ops::Add;
 
 pub static CONFIG_KEY: &[u8] = b"config";
-// pub const OFFERS: Map<&[u8], Offer> = Map::new(OFFERS_KEY);
+
 pub struct OfferIndexes<'a> {
     // pk goes to second tuple element
     pub owner: MultiIndex<'a, String, Offer, String>,
-    pub offer_type: MultiIndex<'a, String, Offer, String>,
-    pub fiat: MultiIndex<'a, String, Offer, String>,
     pub filter: MultiIndex<'a, String, Offer, String>,
 }
 
 impl<'a> IndexList<Offer> for OfferIndexes<'a> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Offer>> + '_> {
-        let v: Vec<&dyn Index<Offer>> =
-            vec![&self.owner, &self.offer_type, &self.fiat, &self.filter];
+        let v: Vec<&dyn Index<Offer>> = vec![&self.owner, &self.filter];
         Box::new(v.into_iter())
     }
 }
@@ -34,22 +32,13 @@ impl<'a> IndexList<Offer> for OfferIndexes<'a> {
 pub fn offers<'a>() -> IndexedMap<'a, String, Offer, OfferIndexes<'a>> {
     let indexes = OfferIndexes {
         owner: MultiIndex::new(|d| d.owner.clone().to_string(), "offers", "offers__owner"),
-        offer_type: MultiIndex::new(
-            |d: &Offer| d.offer_type.to_string(),
-            "offers",
-            "offers__offer_type",
-        ),
-        fiat: MultiIndex::new(
-            |d: &Offer| d.fiat_currency.to_string(),
-            "offers",
-            "offers__fiat",
-        ),
         filter: MultiIndex::new(
             |offer: &Offer| {
                 offer
                     .fiat_currency
                     .to_string()
                     .add(offer.offer_type.to_string().as_str())
+                    .add(denom_to_string(&offer.denom).as_str())
                     .add(&offer.state.to_string())
             },
             "offers",
@@ -126,37 +115,24 @@ pub enum QueryOrder {
 pub enum QueryMsg {
     HubAddr {},
     State {},
-    Offers {
-        // TODO deprecated, remove
-        fiat_currency: FiatCurrency,
+    Offer {
+        id: String,
     },
-    OffersQuery {
+    Offers {
         owner: Option<Addr>,
         min: Option<String>,
         max: Option<String>,
         limit: u32,
         order: QueryOrder,
     },
-    OffersByType {
-        offer_type: OfferType,
-        last_value: Option<String>,
-        limit: u32,
-    },
-    OffersByFiat {
-        fiat_currency: FiatCurrency,
-        last_value: Option<String>,
-        limit: u32,
-    },
-    OffersByTypeFiat {
+    OffersBy {
         offer_type: OfferType,
         fiat_currency: FiatCurrency,
+        denom: Denom,
         min: Option<String>,
         max: Option<String>,
-        limit: u32,
         order: QueryOrder,
-    },
-    Offer {
-        id: String,
+        limit: u32,
     },
     Arbitrator {
         arbitrator: Addr,
@@ -247,120 +223,18 @@ impl OfferModel<'_> {
         &self.offer
     }
 
-    pub fn query_all_offers(
-        storage: &dyn Storage,
-        fiat_currency: FiatCurrency,
-    ) -> StdResult<Vec<Offer>> {
-        let result: Vec<Offer> = offers()
-            .range(storage, None, None, Order::Descending)
-            .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
-            .filter(|offer| offer.fiat_currency == fiat_currency)
-            .collect();
-
-        Ok(result)
-    }
-
-    pub fn query_by_type(
-        deps: Deps,
-        offer_type: OfferType,
-        last_value: Option<String>,
-        limit: u32,
-    ) -> StdResult<Vec<Offer>> {
-        let storage = deps.storage;
-
-        let range_from = match last_value {
-            Some(thing) => Some(Bound::exclusive(thing)),
-            None => None,
-        };
-
-        let result = offers()
-            .idx
-            .offer_type
-            .prefix(offer_type.to_string())
-            .range(storage, range_from, None, Order::Descending)
-            .take(limit as usize)
-            .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
-            .collect();
-
-        Ok(result)
-    }
-
-    pub fn query_by_type_fiat(
-        deps: Deps,
-        offer_type: OfferType,
-        fiat_currency: FiatCurrency,
-        min: Option<String>,
-        max: Option<String>,
-        limit: u32,
-        order: QueryOrder,
-    ) -> StdResult<Vec<Offer>> {
-        let storage = deps.storage;
-
-        let std_order = match order {
-            QueryOrder::Asc => Order::Ascending,
-            QueryOrder::Desc => Order::Descending,
-        };
-
-        let range_min = match min {
-            Some(thing) => Some(Bound::exclusive(thing)),
-            None => None,
-        };
-        let range_max = match max {
-            Some(thing) => Some(Bound::exclusive(thing)),
-            None => None,
-        };
-
-        let result = offers()
-            .idx
-            .filter
-            .prefix(
-                fiat_currency.to_string()
-                    + &offer_type.to_string()
-                    + &*OfferState::Active.to_string(),
-            )
-            .range(storage, range_min, range_max, std_order)
-            .take(limit as usize)
-            .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
-            .collect();
-
-        Ok(result)
-    }
-
-    pub fn query_by_fiat(
-        deps: Deps,
-        fiat_currency: FiatCurrency,
-        last_value: Option<String>,
-        limit: u32,
-    ) -> StdResult<Vec<Offer>> {
-        let storage = deps.storage;
-
-        let range_from = match last_value {
-            Some(thing) => Some(Bound::exclusive(thing)),
-            None => None,
-        };
-
-        let result = offers()
-            .idx
-            .fiat
-            .prefix(fiat_currency.to_string())
-            .range(storage, range_from, None, Order::Descending)
-            .take(limit as usize)
-            .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
-            .collect();
-
-        Ok(result)
-    }
-
     pub fn query(
-        deps: Deps,
+        storage: &dyn Storage,
         owner: Option<Addr>,
         min: Option<String>,
         max: Option<String>,
         limit: u32,
         order: QueryOrder,
     ) -> StdResult<Vec<Offer>> {
-        let storage = deps.storage;
-        // let range: Box<dyn Iterator<Item = StdResult<Pair<Offer>>>>;
+        let std_order = match order {
+            QueryOrder::Asc => Order::Ascending,
+            QueryOrder::Desc => Order::Descending,
+        };
 
         let range_min = match min {
             Some(thing) => Some(Bound::ExclusiveRaw(thing.into())),
@@ -370,11 +244,6 @@ impl OfferModel<'_> {
         let range_max = match max {
             Some(thing) => Some(Bound::ExclusiveRaw(thing.into())),
             None => None,
-        };
-
-        let std_order = match order {
-            QueryOrder::Asc => Order::Ascending,
-            QueryOrder::Desc => Order::Descending,
         };
 
         // Handle optional owner address query parameter
@@ -392,6 +261,48 @@ impl OfferModel<'_> {
         };
 
         let result = range
+            .take(limit as usize)
+            .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
+            .collect();
+
+        Ok(result)
+    }
+
+    pub fn query_by(
+        storage: &dyn Storage,
+        offer_type: OfferType,
+        fiat_currency: FiatCurrency,
+        denom: Denom,
+        min: Option<String>,
+        max: Option<String>,
+        order: QueryOrder,
+        limit: u32,
+    ) -> StdResult<Vec<Offer>> {
+        let std_order = match order {
+            QueryOrder::Asc => Order::Ascending,
+            QueryOrder::Desc => Order::Descending,
+        };
+
+        let range_min = match min {
+            Some(thing) => Some(Bound::exclusive(thing)),
+            None => None,
+        };
+
+        let range_max = match max {
+            Some(thing) => Some(Bound::exclusive(thing)),
+            None => None,
+        };
+
+        let result = offers()
+            .idx
+            .filter
+            .prefix(
+                fiat_currency.to_string()
+                    + &offer_type.to_string()
+                    + &denom_to_string(&denom)
+                    + &*OfferState::Active.to_string(),
+            )
+            .range(storage, range_min, range_max, std_order)
             .take(limit as usize)
             .flat_map(|item| item.and_then(|(_, offer)| Ok(offer)))
             .collect();

--- a/contracts/packages/protocol/src/offer.rs
+++ b/contracts/packages/protocol/src/offer.rs
@@ -224,13 +224,15 @@ impl OfferModel<'_> {
     }
 
     pub fn query(
-        storage: &dyn Storage,
+        deps: Deps,
         owner: Option<Addr>,
         min: Option<String>,
         max: Option<String>,
         limit: u32,
         order: QueryOrder,
     ) -> StdResult<Vec<Offer>> {
+        let storage = deps.storage;
+
         let std_order = match order {
             QueryOrder::Asc => Order::Ascending,
             QueryOrder::Desc => Order::Descending,

--- a/integration-tests/index.js
+++ b/integration-tests/index.js
@@ -109,7 +109,7 @@ async function create_offers(offer_addr) {
 async function query_offers(offer_addr) {
   const queries = [
     {
-      offers_query: {
+      offers: {
         limit: 5,
         order: 'desc'
       },


### PR DESCRIPTION
Task: LOCAL-750
Description:
- prepares front-end to filter by `type`, `denom` and `fiat`
- deletes unused offers queries: `OffersByType` and `OffersByFiat`
- replaces `OfferByTypeFiat` with `OffersBy` query, that filters by `type`, `denom` and `fiat`
- updates integration tests