### PR TITLE
fix: windows line break

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -9,7 +9,8 @@
       "semi": false,
       "singleQuote": true,
       "tabWidth": 2,
-      "trailingComma": "es5"
+      "trailingComma": "es5",
+      "endOfLine": "auto"
     }],
     "curly": ["error", "all"],
     "arrow-parens": ["error", "always"],


### PR DESCRIPTION
task: local-803
I was getting an error regarding "breaking line type" on my windows setup. That happens because Windows and Unix use different control characters for this, CR LF and LF respectively.
This solution apparently solves cross platform problems.