### PR TITLE
fix: generate trade id using requested_trades_count

### DIFF
--- a/app/src/types/components.interface.ts
+++ b/app/src/types/components.interface.ts
@@ -35,7 +35,8 @@ export interface OfferResponse {
 export interface Profile {
   addr: string
   created_at: Date
-  trades_count: number
+  requested_trades_count: number
+  released_trades_count: number
   last_trade: Date
   contact?: string
   encryption_key?: string
@@ -52,7 +53,6 @@ export interface GetOffer {
   denom: Denom
   fiat_currency: FiatCurrency
   timestamp: number
-  trades_count: number
 }
 
 export interface PatchOffer {

--- a/app/src/ui/components/offers/CollapsedOffer.vue
+++ b/app/src/ui/components/offers/CollapsedOffer.vue
@@ -32,7 +32,7 @@ const offerPrice = computed(() => {
       <p class="wallet-addr">
         {{ formatAddress(offerResponse.offer.owner) }}
       </p>
-      <p class="n-trades">{{ formatTradesCountInfo(offerResponse.profile.trades_count) }}</p>
+      <p class="n-trades">{{ formatTradesCountInfo(offerResponse.profile.released_trades_count) }}</p>
     </div>
 
     <div class="info">

--- a/app/src/ui/components/offers/ExpandedOffer.vue
+++ b/app/src/ui/components/offers/ExpandedOffer.vue
@@ -192,7 +192,7 @@ onUnmounted(() => {
       <p class="wallet">
         {{ formatAddress(offerResponse.offer.owner) }}
       </p>
-      <p class="n-trades">{{ formatTradesCountInfo(offerResponse.offer.trades_count) }}</p>
+      <p class="n-trades">{{ formatTradesCountInfo(offerResponse.profile.released_trades_count) }}</p>
     </div>
 
     <div class="divider-horizontal" />

--- a/app/tests/arbitration.spec.ts
+++ b/app/tests/arbitration.spec.ts
@@ -9,7 +9,7 @@ import takerSecrets from './fixtures/taker_secrets.json'
 import makerSecrets from './fixtures/maker_secrets.json'
 import adminSecrets from './fixtures/admin_secrets.json'
 import type { FiatCurrency, GetOffer, OfferResponse, PostOffer } from '~/types/components.interface'
-import { TradeState } from '~/types/components.interface'
+import { OfferOrder, TradeState } from '~/types/components.interface'
 
 dotenv.config()
 Object.assign(global, { TextEncoder, TextDecoder })
@@ -60,6 +60,7 @@ describe('arbitration tests', () => {
       denom: createdOffer.denom,
       fiatCurrency: createdOffer.fiat_currency,
       offerType: createdOffer.offer_type,
+      order: OfferOrder.trades_count,
     })
     offer = offerResponse[0].offer as GetOffer
     expect(offer.id.length).toBeGreaterThan(0)

--- a/app/tests/trade.spec.ts
+++ b/app/tests/trade.spec.ts
@@ -35,7 +35,8 @@ offers[0].denom = { native: process.env.OFFER_DENOM! }
 let myOffers: OfferResponse[] = []
 
 describe('trade lifecycle happy path', () => {
-  let offerTradeCount = 0
+  let requestedTradesCount = 0
+  let releasedTradesCount = 0
   it('should have an arbitrator available', async () => {
     const fiat = offers[0].fiat_currency as FiatCurrency
     let arbitrators = await adminClient.fetchArbitrators()
@@ -59,7 +60,8 @@ describe('trade lifecycle happy path', () => {
       await makerClient.createOffer(offer)
     }
     myOffers = await makerClient.fetchMyOffers()
-    offerTradeCount = myOffers[0].profile.trades_count
+    requestedTradesCount = myOffers[0].profile.requested_trades_count
+    releasedTradesCount = myOffers[0].profile.released_trades_count
     expect(myOffers.length).toBeGreaterThan(0)
   })
   // Create Trade
@@ -117,12 +119,14 @@ describe('trade lifecycle happy path', () => {
   })
   it('the trade count should increase after the release', async () => {
     const myOffers = await makerClient.fetchMyOffers()
-    expect(myOffers[0].profile.trades_count).toBe(offerTradeCount + 1)
+    expect(myOffers[0].profile.requested_trades_count).toBe(requestedTradesCount + 1)
+    expect(myOffers[0].profile.released_trades_count).toBe(releasedTradesCount + 1)
   })
 })
 
 describe('trade invalid state changes', () => {
-  let offerTradeCount = 0
+  let requestedTradesCount = 0
+  let releasedTradesCount = 0
   it('should have an arbitrator available', async () => {
     const fiat = offers[0].fiat_currency as FiatCurrency
     let arbitrators = await adminClient.fetchArbitrators()
@@ -146,7 +150,8 @@ describe('trade invalid state changes', () => {
       await makerClient.createOffer(newOffer)
     }
     myOffers = await makerClient.fetchMyOffers()
-    offerTradeCount = myOffers[0].profile.trades_count
+    requestedTradesCount = myOffers[0].profile.requested_trades_count
+    releasedTradesCount = myOffers[0].profile.released_trades_count
   })
   it('should fail to fund a trade in request_created state', async () => {
     const offerResponse = myOffers[0] as OfferResponse
@@ -210,6 +215,7 @@ describe('trade invalid state changes', () => {
   })
   it('the trade count should not increase when a trade is not completed', async () => {
     const myOffers = await makerClient.fetchMyOffers()
-    expect(myOffers[0].profile.trades_count).toBe(offerTradeCount)
+    expect(myOffers[0].profile.requested_trades_count).toBe(requestedTradesCount + 1)
+    expect(myOffers[0].profile.released_trades_count).toBe(releasedTradesCount)
   })
 })

--- a/contracts/packages/protocol/src/offer.rs
+++ b/contracts/packages/protocol/src/offer.rs
@@ -85,7 +85,6 @@ pub enum ExecuteMsg {
     //TODO: Change to Create(OfferMsg)
     Create { offer: OfferMsg },
     UpdateOffer { offer_update: OfferUpdateMsg },
-    IncrementTradesCount { offer_id: String },
     RegisterHub {},
 }
 
@@ -128,7 +127,6 @@ pub struct Offer {
     pub denom: Denom,
     pub state: OfferState,
     pub timestamp: u64,
-    pub trades_count: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -177,12 +175,6 @@ impl OfferModel<'_> {
         self.offer.min_amount = msg.min_amount;
         self.offer.max_amount = msg.max_amount;
         self.offer.state = msg.state;
-        OfferModel::store(self.storage, &self.offer).unwrap();
-        &self.offer
-    }
-
-    pub fn increment_trades_count(&mut self) -> &Offer {
-        self.offer.trades_count += 1;
         OfferModel::store(self.storage, &self.offer).unwrap();
         &self.offer
     }
@@ -284,7 +276,9 @@ impl OfferModel<'_> {
         match order {
             OfferOrder::TradesCount => {
                 result.sort_by(|prev, next| {
-                    next.profile.trades_count.cmp(&prev.profile.trades_count)
+                    next.profile
+                        .released_trades_count
+                        .cmp(&prev.profile.released_trades_count)
                 });
             }
             OfferOrder::PriceRate => {

--- a/contracts/packages/protocol/src/profile.rs
+++ b/contracts/packages/protocol/src/profile.rs
@@ -21,7 +21,7 @@ pub enum ExecuteMsg {
     },
     IncreaseTradeCount {
         profile_addr: Addr,
-        final_trade_state: TradeState,
+        trade_state: TradeState,
     },
     RegisterHub {},
 }
@@ -59,13 +59,13 @@ pub fn update_profile_msg(
 pub fn increase_profile_trades_count_msg(
     profile_contract: String,
     profile_addr: Addr,
-    final_trade_state: TradeState,
+    trade_state: TradeState,
 ) -> SubMsg {
     SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: profile_contract,
         msg: to_binary(&ExecuteMsg::IncreaseTradeCount {
             profile_addr,
-            final_trade_state,
+            trade_state,
         })
         .unwrap(),
         funds: vec![],
@@ -100,7 +100,8 @@ pub fn load_profiles(
 pub struct Profile {
     pub addr: Addr,
     pub created_at: u64,
-    pub trades_count: u64,
+    pub requested_trades_count: u64,
+    pub released_trades_count: u64,
     pub last_trade: u64,
     pub contact: Option<String>,
     pub encryption_key: Option<String>,
@@ -111,7 +112,8 @@ impl Profile {
         Profile {
             addr,
             created_at,
-            trades_count: 0,
+            released_trades_count: 0,
+            requested_trades_count: 0,
             last_trade: 0,
             contact: None,
             encryption_key: None,
@@ -194,7 +196,7 @@ pub fn profiles<'a>() -> IndexedMap<'a, String, Profile, ProfileIndexes<'a>> {
             "profiles__address",
         ),
         trades_count: MultiIndex::new(
-            |p: &Profile| p.trades_count,
+            |p: &Profile| p.released_trades_count,
             "profiles",
             "profiles__trades_count",
         ),


### PR DESCRIPTION
task: LOCAL-867
description: 
- adds `requested_trades_count` on `Profile`
- adds `released_trades_count` on `Profile`
- uses `requested_trades_count` to generate the trade id and fixes the overwrite open trades bug
- replaces `trades_count` for `released_trades_count`