### PR TITLE
feat: trade detail expiration timer

### DIFF
--- a/app/src/network/Chain.ts
+++ b/app/src/network/Chain.ts
@@ -10,7 +10,6 @@ import type {
   PatchOffer,
   PostOffer,
   Profile,
-  Trade,
   TradeInfo,
 } from '~/types/components.interface'
 import { CosmosChain } from '~/network/cosmos/CosmosChain'
@@ -40,7 +39,7 @@ export interface Chain {
 
   fetchDisputedTrades(): Promise<{ openDisputes: TradeInfo[]; closedDisputes: TradeInfo[] }>
 
-  fetchTradeDetail(tradeId: string): Promise<Trade>
+  fetchTradeDetail(tradeId: string): Promise<TradeInfo>
 
   fetchArbitrators(): Promise<Arbitrator[]>
 

--- a/app/src/network/cosmos/CosmosChain.ts
+++ b/app/src/network/cosmos/CosmosChain.ts
@@ -17,7 +17,6 @@ import type {
   PatchOffer,
   PostOffer,
   Profile,
-  Trade,
   TradeInfo,
 } from '~/types/components.interface'
 
@@ -281,7 +280,7 @@ export class CosmosChain implements Chain {
     try {
       const response = (await this.cwClient!.queryContractSmart(this.hubInfo.hubConfig.trade_addr, {
         trade: { id: tradeId },
-      })) as Trade
+      })) as TradeInfo
       return response
     } catch (e) {
       // TODO error state

--- a/app/src/stores/client.ts
+++ b/app/src/stores/client.ts
@@ -161,20 +161,8 @@ export const useClientStore = defineStore({
     },
     async fetchTradeDetail(tradeId: string) {
       // TODO the fetchTradeDetail should return a TradeInfo
-      const trade = await this.client.fetchTradeDetail(tradeId)
-      if (this.userWallet.address === trade.arbitrator) {
-        const offer = await this.client.fetchOffer(trade.offer_id)
-        return {
-          offer,
-          trade,
-          expired: false,
-        } as TradeInfo
-      } else {
-        await this.fetchMyTrades()
-        const tradeIndex = this.trades.data.findIndex((trade) => trade.trade.id === tradeId)
-        this.trades.data[tradeIndex].trade = trade
-        return this.trades.data[tradeIndex]
-      }
+      const tradeInfo = await this.client.fetchTradeDetail(tradeId)
+      return tradeInfo
     },
     async fetchArbitrators() {
       this.arbitrators = ListResult.loading()

--- a/app/src/types/components.interface.ts
+++ b/app/src/types/components.interface.ts
@@ -125,6 +125,7 @@ export interface Trade {
   offer_contract: string
   offer_id: string
   created_at: number
+  expires_at: number
   amount: string
   denom: Denom
   state: TradeState

--- a/app/src/ui/components/trades/TradeOpenItem.vue
+++ b/app/src/ui/components/trades/TradeOpenItem.vue
@@ -5,6 +5,7 @@ import type { TradeInfo } from '~/types/components.interface'
 import { microDenomToDenom } from '~/utils/denom'
 import { formatTimer } from '~/utils/formatters'
 import { checkTradeNeedsRefund } from '~/utils/validations'
+import { TradeState } from '~/types/components.interface'
 
 const props = defineProps<{ tradeInfo: TradeInfo }>()
 const client = useClientStore()
@@ -111,7 +112,7 @@ const stepLabel = computed(() => {
     return stepLabels[type].buyer[labelIdx]
   } else {
     if (checkTradeNeedsRefund(props.tradeInfo.trade, walletAddress.value)) {
-      return 'You can refund this trade'
+      return 'Refund available'
     } else {
       return stepLabels[type].seller[labelIdx]
     }
@@ -183,12 +184,14 @@ onUnmounted(() => {
         </p>
       </div>
 
-      <div class="divider" />
+      <template v-if="tradeInfo.trade.state !== TradeState.request_expired && tradeInfo.trade.expires_at > 0">
+        <div class="divider" />
 
-      <div class="wrap">
-        <p class="label">Time remaining</p>
-        <p class="content">{{ tradeTimer }}</p>
-      </div>
+        <div class="wrap">
+          <p class="label">Time remaining</p>
+          <p class="content">{{ tradeTimer }}</p>
+        </div>
+      </template>
     </div>
 
     <div class="price">

--- a/app/src/ui/components/trades/TradeOpenItem.vue
+++ b/app/src/ui/components/trades/TradeOpenItem.vue
@@ -4,6 +4,7 @@ import { useClientStore } from '~/stores/client'
 import type { TradeInfo } from '~/types/components.interface'
 import { microDenomToDenom } from '~/utils/denom'
 import { formatTimer } from '~/utils/formatters'
+import { checkTradeNeedsRefund } from '~/utils/validations'
 
 const props = defineProps<{ tradeInfo: TradeInfo }>()
 const client = useClientStore()
@@ -109,7 +110,11 @@ const stepLabel = computed(() => {
   if (isBuying.value) {
     return stepLabels[type].buyer[labelIdx]
   } else {
-    return stepLabels[type].seller[labelIdx]
+    if (checkTradeNeedsRefund(props.tradeInfo.trade, walletAddress.value)) {
+      return 'You can refund this trade'
+    } else {
+      return stepLabels[type].seller[labelIdx]
+    }
   }
 })
 

--- a/app/src/ui/components/trades/TradeOpenItem.vue
+++ b/app/src/ui/components/trades/TradeOpenItem.vue
@@ -132,10 +132,10 @@ function startTradeDetailRefresh() {
 }
 
 function startTradeTimer() {
-  tradeTimerInterval = setInterval(tradeTimerRunning, 10)
+  tradeTimerInterval = setInterval(tradeTimerTick, 10)
 }
 
-function tradeTimerRunning() {
+function tradeTimerTick() {
   const currentTime = Date.now()
   const expiresAt = props.tradeInfo.trade.expires_at * 1000
   const timer = new Date(expiresAt - currentTime)

--- a/app/src/ui/pages/TradeDetail.vue
+++ b/app/src/ui/pages/TradeDetail.vue
@@ -109,10 +109,10 @@ const contactsForArbitrator = computed(() => {
 })
 
 function startTradeTimer() {
-  tradeTimerInterval = setInterval(tradeTimerRunning, 10)
+  tradeTimerInterval = setInterval(tradeTimerTick, 10)
 }
 
-function tradeTimerRunning() {
+function tradeTimerTick() {
   const currentTime = Date.now()
   const expiresAt = tradeInfo.value.trade.expires_at * 1000
   const timer = new Date(expiresAt - currentTime)

--- a/app/src/ui/pages/TradeDetail.vue
+++ b/app/src/ui/pages/TradeDetail.vue
@@ -13,6 +13,7 @@ import { usePriceStore } from '~/stores/price'
 import { microDenomToDenom } from '~/utils/denom'
 import { decryptData } from '~/utils/crypto'
 import { formatTimer } from '~/utils/formatters'
+import { TradeState } from '~/types/components.interface'
 
 const client = useClientStore()
 const { userWallet } = storeToRefs(client)
@@ -240,7 +241,10 @@ watch(userWallet, async () => {
         </template>
       </div>
 
-      <div class="step-status">
+      <div
+        v-if="tradeInfo.trade.state !== TradeState.request_expired && tradeInfo.trade.expires_at > 0"
+        class="step-status"
+      >
         <div class="separator" />
         <div class="wrap">
           <p>time remaining</p>

--- a/app/src/ui/pages/Trades.vue
+++ b/app/src/ui/pages/Trades.vue
@@ -20,31 +20,27 @@ const trades = computed(() => {
 })
 
 const openTrades = computed(() => {
-  return trades.value.filter(
-    (tradeInfo) =>
-      !tradeInfo.expired &&
-      [
-        TradeState.request_created,
-        TradeState.request_accepted,
-        TradeState.escrow_funded,
-        TradeState.fiat_deposited,
-        TradeState.escrow_disputed,
-      ].includes(tradeInfo.trade.state)
+  return trades.value.filter((tradeInfo) =>
+    [
+      TradeState.request_created,
+      TradeState.request_accepted,
+      TradeState.escrow_funded,
+      TradeState.fiat_deposited,
+      TradeState.escrow_disputed,
+    ].includes(tradeInfo.trade.state)
   )
 })
 
 const closedTrades = computed(() => {
-  return trades.value.filter(
-    (tradeInfo) =>
-      tradeInfo.expired ||
-      [
-        TradeState.request_canceled,
-        TradeState.request_expired,
-        TradeState.escrow_refunded,
-        TradeState.escrow_released,
-        TradeState.settled_for_maker,
-        TradeState.settled_for_taker,
-      ].includes(tradeInfo.trade.state)
+  return trades.value.filter((tradeInfo) =>
+    [
+      TradeState.request_canceled,
+      TradeState.request_expired,
+      TradeState.escrow_refunded,
+      TradeState.escrow_released,
+      TradeState.settled_for_maker,
+      TradeState.settled_for_taker,
+    ].includes(tradeInfo.trade.state)
   )
 })
 

--- a/app/src/ui/pages/Trades.vue
+++ b/app/src/ui/pages/Trades.vue
@@ -4,7 +4,7 @@ import TradeOpenItem from '../components/trades/TradeOpenItem.vue'
 import TradeHistoryItem from '../components/trades/TradeHistoryItem.vue'
 import { useClientStore } from '~/stores/client'
 import { TradeState } from '~/types/components.interface'
-import { checkValidOffer } from '~/utils/validations'
+import { checkTradeNeedsRefund, checkValidOffer } from '~/utils/validations'
 
 const client = useClientStore()
 const { userWallet } = storeToRefs(client)
@@ -20,28 +20,32 @@ const trades = computed(() => {
 })
 
 const openTrades = computed(() => {
-  return trades.value.filter((tradeInfo) =>
-    [
-      TradeState.request_created,
-      TradeState.request_accepted,
-      TradeState.escrow_funded,
-      TradeState.fiat_deposited,
-      TradeState.escrow_disputed,
-    ].includes(tradeInfo.trade.state)
-  )
+  return trades.value.filter((tradeInfo) => {
+    return (
+      [
+        TradeState.request_created,
+        TradeState.request_accepted,
+        TradeState.escrow_funded,
+        TradeState.fiat_deposited,
+        TradeState.escrow_disputed,
+      ].includes(tradeInfo.trade.state) || checkTradeNeedsRefund(tradeInfo.trade, userWallet.value.address)
+    )
+  })
 })
 
 const closedTrades = computed(() => {
-  return trades.value.filter((tradeInfo) =>
-    [
-      TradeState.request_canceled,
-      TradeState.request_expired,
-      TradeState.escrow_refunded,
-      TradeState.escrow_released,
-      TradeState.settled_for_maker,
-      TradeState.settled_for_taker,
-    ].includes(tradeInfo.trade.state)
-  )
+  return trades.value.filter((tradeInfo) => {
+    return (
+      [
+        TradeState.request_canceled,
+        TradeState.request_expired,
+        TradeState.escrow_refunded,
+        TradeState.escrow_released,
+        TradeState.settled_for_maker,
+        TradeState.settled_for_taker,
+      ].includes(tradeInfo.trade.state) && !checkTradeNeedsRefund(tradeInfo.trade, userWallet.value.address)
+    )
+  })
 })
 
 const hasOpenTrades = computed(() => openTrades.value.length > 0)

--- a/app/src/utils/formatters.ts
+++ b/app/src/utils/formatters.ts
@@ -1,0 +1,15 @@
+export function formatTimer(timer: Date, finalState: string): string {
+  const hours = zeroPrefix(timer.getUTCHours(), 2)
+  const mins = zeroPrefix(timer.getUTCMinutes(), 2)
+  const secs = zeroPrefix(timer.getUTCSeconds(), 2)
+  const timerRunning = timer.getUTCHours() !== 0 ? `${hours}h ${mins}m ${secs}s` : `${mins}m ${secs}s`
+  return timer.getTime() > 0 ? timerRunning : finalState
+}
+
+function zeroPrefix(num: number, digit: number): string {
+  let zero = ''
+  for (let i = 0; i < digit; i++) {
+    zero += '0'
+  }
+  return (zero + num).slice(-digit)
+}

--- a/app/src/utils/validations.ts
+++ b/app/src/utils/validations.ts
@@ -1,7 +1,15 @@
-import type { GetOffer } from '~/types/components.interface'
+import type { GetOffer, Trade } from '~/types/components.interface'
 import { checkMicroDenomAvailable } from '~/utils/denom'
 import { checkFiatAvailable } from '~/utils/fiat'
+import { TradeState } from '~/types/components.interface'
 
 export function checkValidOffer(offer: GetOffer): boolean {
   return checkMicroDenomAvailable(offer.denom.native) && checkFiatAvailable(offer.fiat_currency)
+}
+
+export function checkTradeNeedsRefund(trade: Trade, userAddr: string): boolean {
+  const isSeller = trade.seller === userAddr
+  const lastStateIndex = trade.state_history.length - 1
+  const lastTradeState = trade.state_history[lastStateIndex].state
+  return isSeller && trade.state === TradeState.request_expired && lastTradeState === TradeState.escrow_funded
 }

--- a/app/tests/arbitration.spec.ts
+++ b/app/tests/arbitration.spec.ts
@@ -80,24 +80,28 @@ describe('arbitration tests', () => {
       taker_contact,
     })
 
-    let trade = await makerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     const makerContactEncrypted = await encryptDataMocked(trade.seller_encryption_key, makerContact)
     await makerClient.acceptTradeRequest(tradeId, makerContactEncrypted)
     await takerClient.fundEscrow(trade.id, trade.amount, trade.denom)
     await makerClient.setFiatDeposited(trade.id)
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await takerClient.fetchTradeDetail(trade.id)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.fiat_deposited)
 
     // Taker disputes the escrow
     const buyer_contact = await encryptDataMocked(makerContact, trade.arbitrator_encryption_key)
     const seller_contact = await encryptDataMocked(taker_contact, trade.arbitrator_encryption_key)
     await takerClient.openDispute(trade.id, buyer_contact, seller_contact)
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await takerClient.fetchTradeDetail(trade.id)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.escrow_disputed)
 
     // Arbitrator settles for Taker
     await adminClient.settleDispute(trade.id, takerClient.getWalletAddress())
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await takerClient.fetchTradeDetail(trade.id)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.settled_for_taker)
   })
 
@@ -115,7 +119,8 @@ describe('arbitration tests', () => {
       taker_contact,
     })
 
-    let trade = await makerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     const makerContactEncrypted = await encryptDataMocked(trade.seller_encryption_key, makerContact)
     await makerClient.acceptTradeRequest(tradeId, makerContactEncrypted)
     await takerClient.fundEscrow(trade.id, trade.amount, trade.denom)
@@ -123,12 +128,14 @@ describe('arbitration tests', () => {
 
     // Taker disputes the escrow
     await takerClient.openDispute(trade.id, 'buyer_contact', 'seller_contact')
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.escrow_disputed)
 
     // Arbitrator settles for Maker
     await adminClient.settleDispute(trade.id, makerClient.getWalletAddress())
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.settled_for_maker)
   })
 

--- a/app/tests/trade.spec.ts
+++ b/app/tests/trade.spec.ts
@@ -84,38 +84,42 @@ describe('trade lifecycle happy path', () => {
   })
   // Maker accepts the trade request
   it('maker should accept the trade request', async () => {
-    let trade = await makerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     const decryptedTakerContact = await decryptDataMocked(makerSecrets.privateKey, trade.seller_contact!)
     expect(decryptedTakerContact).toBe(takerContact)
     expect(trade.id).toBe(tradeId)
     expect(trade.state).toBe(TradeState.request_created)
     const maker_contact = await encryptDataMocked(trade.seller_encryption_key, makerContact)
     await makerClient.acceptTradeRequest(trade.id, maker_contact)
-    trade = await makerClient.fetchTradeDetail(tradeId)
+    tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.request_accepted)
   })
   // Taker funds the escrow
   it('taker should fund the escrow', async () => {
     const tradeAddr = makerClient.getHubInfo().hubConfig.trade_addr
-    let trade = await takerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await takerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     const decryptedMakerContact = await decryptDataMocked(takerSecrets.privateKey, trade.buyer_contact!)
     expect(decryptedMakerContact).toBe(offers[0].owner_contact)
     const tradeBalance = (await makerClient.getCwClient().getBalance(tradeAddr, trade.denom.native)).amount
     await takerClient.fundEscrow(trade.id, trade.amount, trade.denom)
     const newTradeBalance = (await makerClient.getCwClient().getBalance(tradeAddr, trade.denom.native)).amount
-    trade = await takerClient.fetchTradeDetail(tradeId)
+    tradeInfo = await takerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.escrow_funded)
     expect(parseInt(newTradeBalance)).toBe(parseInt(tradeBalance) + parseInt(trade.amount) * 1.01)
   })
   it('maker should mark trade as paid (fiat_deposited)', async () => {
     await makerClient.setFiatDeposited(tradeId)
-    const trade = await makerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.fiat_deposited)
+    const tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.fiat_deposited)
   })
   it('taker should release the trade.', async () => {
     await takerClient.releaseEscrow(tradeId)
-    const trade = await takerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.escrow_released)
+    const tradeInfo = await takerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.escrow_released)
   })
   it('the trade count should increase after the release', async () => {
     const myOffers = await makerClient.fetchMyOffers()
@@ -167,51 +171,57 @@ describe('trade invalid state changes', () => {
       profile_taker_encryption_key: taker_encrypt_pk,
       taker_contact,
     })
-    let trade = await takerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await takerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.request_created)
     // Taker tries to fund escrow before maker accepts the trade
     await expect(takerClient.fundEscrow(trade.id, trade.amount, trade.denom)).rejects.toThrow(DefaultError)
-    trade = await takerClient.fetchTradeDetail(trade.id)
+    tradeInfo = await takerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.request_created)
   })
   it('should fail to mark as paid a trade in request_created state', async () => {
-    const trade = await makerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.request_created)
+    const tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.request_created)
     await expect(makerClient.setFiatDeposited(tradeId)).rejects.toThrow()
   })
   it('should fail to release or refund escrow of trade in request_created state', async () => {
-    const trade = await makerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.request_created)
+    const tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.request_created)
     await expect(takerClient.releaseEscrow(tradeId)).rejects.toThrow()
     await expect(takerClient.refundEscrow(tradeId)).rejects.toThrow()
   })
   it('should fail to mark as paid a trade in request_accepted state', async () => {
     const offer = offers[0] as PostOffer
-    let trade = await makerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     const maker_contact = await encryptDataMocked(trade.seller_encryption_key, offer.owner_contact)
     await makerClient.acceptTradeRequest(trade.id, maker_contact)
-    trade = await makerClient.fetchTradeDetail(tradeId)
+    tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.request_accepted)
     await expect(takerClient.setFiatDeposited(tradeId)).rejects.toThrow()
   })
   it('should fail to release or refund a trade in request_accepted state', async () => {
-    const trade = await makerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.request_accepted)
+    const tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.request_accepted)
     await expect(takerClient.releaseEscrow(tradeId)).rejects.toThrow()
     await expect(takerClient.refundEscrow(tradeId)).rejects.toThrow()
   })
   it('should fail to release or refund a trade in escrow_funded state', async () => {
-    let trade = await makerClient.fetchTradeDetail(tradeId)
+    let tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    let trade = tradeInfo.trade
     await takerClient.fundEscrow(trade.id, trade.amount, trade.denom)
-    trade = await makerClient.fetchTradeDetail(tradeId)
+    tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    trade = tradeInfo.trade
     expect(trade.state).toBe(TradeState.escrow_funded)
   })
   it('should fail to cancel a trade in fiat_deposited state', async () => {
     await makerClient.setFiatDeposited(tradeId)
-    const trade = await makerClient.fetchTradeDetail(tradeId)
-    expect(trade.state).toBe(TradeState.fiat_deposited)
+    const tradeInfo = await makerClient.fetchTradeDetail(tradeId)
+    expect(tradeInfo.trade.state).toBe(TradeState.fiat_deposited)
     await expect(makerClient.cancelTradeRequest(tradeId)).rejects.toThrow()
-    expect(trade.state).toBe(TradeState.fiat_deposited)
+    expect(tradeInfo.trade.state).toBe(TradeState.fiat_deposited)
   })
   it('the trade count should not increase when a trade is not completed', async () => {
     const myOffers = await makerClient.fetchMyOffers()

--- a/app/tests/utils.ts
+++ b/app/tests/utils.ts
@@ -22,6 +22,7 @@ export function createHubUpdateConfigMsg(
       warchest_fee_pct: '50',
       chain_fee_pct: '10',
       burn_fee_pct: '40',
+      trade_expiration_timer: 20 * 60, // 20 minutes
     },
   }
 }

--- a/contracts/contracts/hub/src/contract.rs
+++ b/contracts/contracts/hub/src/contract.rs
@@ -1,14 +1,15 @@
 use cosmwasm_std::{entry_point, Addr, Binary, Deps, StdResult};
 use cosmwasm_std::{to_binary, CosmosMsg, DepsMut, Env, MessageInfo, Response, SubMsg, WasmMsg};
-use cw20::Denom;
+use localterra_protocol::denom_utils::denom_to_string;
 
 use localterra_protocol::errors::ContractError;
 use localterra_protocol::errors::ContractError::Unauthorized;
-use localterra_protocol::hub::{Admin, ExecuteMsg, HubConfig, InstantiateMsg, QueryMsg};
+use localterra_protocol::hub::{
+    Admin, ExecuteMsg, HubConfig, InstantiateMsg, MigrateMsg, QueryMsg,
+};
 use localterra_protocol::offer::ExecuteMsg::RegisterHub as OfferRegisterHub;
 use localterra_protocol::profile::ExecuteMsg::RegisterHub as ProfileRegisterHub;
 use localterra_protocol::trade::ExecuteMsg::RegisterHub as TradeRegisterHub;
-use localterra_protocol::trade::MigrateMsg;
 use localterra_protocol::trading_incentives::ExecuteMsg::RegisterHub as TradeIncentivesRegisterHub;
 
 use crate::state::{ADMIN, CONFIG};
@@ -57,10 +58,7 @@ fn update_config(
         });
     }
     CONFIG.save(deps.storage, &config).unwrap();
-    let local_denom = match config.local_denom {
-        Denom::Native(s) => s,
-        Denom::Cw20(addr) => addr.to_string(),
-    };
+    let local_denom = denom_to_string(&config.local_denom);
 
     let offer_register_hub = SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: config.offer_addr.to_string(),

--- a/contracts/contracts/trade/src/contract.rs
+++ b/contracts/contracts/trade/src/contract.rs
@@ -344,7 +344,6 @@ fn fund_escrow(
 
     // Everybody can set the state to RequestExpired, if it is expired (they are doing as a favor).
     if trade.request_expired(env.block.time.seconds()) {
-        // TODO: will the store save it if we return an error?
         trade.set_state(TradeState::RequestExpired, &env, &info);
         TradeModel::store(deps.storage, &trade).unwrap();
 

--- a/contracts/contracts/trading_incentives/src/contract.rs
+++ b/contracts/contracts/trading_incentives/src/contract.rs
@@ -14,8 +14,8 @@ use localterra_protocol::errors::ContractError::{
     InvalidTradeState, Unauthorized,
 };
 use localterra_protocol::hub_utils::{get_hub_config, register_hub_internal};
-use localterra_protocol::offer::load_offer;
-use localterra_protocol::trade::{QueryMsg as TradeQueryMsg, TradeResponse, TradeState};
+use localterra_protocol::offer::TradeInfo;
+use localterra_protocol::trade::{QueryMsg as TradeQueryMsg, TradeState};
 use localterra_protocol::trading_incentives::{
     Distribution, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, TraderRewards,
 };
@@ -131,7 +131,7 @@ fn register_trade(
         });
     }
 
-    let trade: TradeResponse = deps
+    let trade_info: TradeInfo = deps
         .querier
         .query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: hub_cfg.trade_addr.to_string(),
@@ -142,14 +142,9 @@ fn register_trade(
         }))
         .unwrap();
 
-    let offer = load_offer(
-        &deps.querier,
-        trade.offer_id.to_string(),
-        hub_cfg.offer_addr.to_string(),
-    )
-    .unwrap()
-    .offer;
-    let maker = offer.owner.to_string();
+    let trade = trade_info.trade;
+    let offer_response = trade_info.offer;
+    let maker = offer_response.offer.owner.to_string();
 
     if trade.state != TradeState::EscrowReleased {
         return Err(InvalidTradeState {

--- a/contracts/packages/protocol/src/constants.rs
+++ b/contracts/packages/protocol/src/constants.rs
@@ -1,5 +1,3 @@
-pub const REQUEST_TIMEOUT: u64 = 20 * 60; // 20 mins
-pub const FUNDING_TIMEOUT: u64 = 140 * 60; // 2hrs 20 mins
 pub const LOCAL_FEE: u128 = 100;
 pub const ARBITRATION_FEE: u128 = 10;
 pub const OFFERS_QUERY_PROFILES_LIMIT: u32 = 10;

--- a/contracts/packages/protocol/src/errors.rs
+++ b/contracts/packages/protocol/src/errors.rs
@@ -59,11 +59,7 @@ pub enum ContractError {
     #[error("Refund error: Not Expired")]
     RefundErrorNotExpired { message: String, trade: String },
     #[error("This trade has expired.")]
-    TradeExpired {
-        timeout: u64,
-        expired_at: u64,
-        created_at: u64,
-    },
+    TradeExpired { expired_at: u64, created_at: u64 },
     /// TradingIncentives Errors
     #[error("Only past periods can be claimed.")]
     DistributionClaimInvalidPeriod {},

--- a/contracts/packages/protocol/src/guards.rs
+++ b/contracts/packages/protocol/src/guards.rs
@@ -85,10 +85,6 @@ pub fn assert_range_0_to_99(random_value: usize) -> Result<(), ContractError> {
     }
 }
 
-pub fn trade_request_is_expired(block_time: u64, created_at: u64, expire_timer: u64) -> bool {
-    block_time > created_at + expire_timer
-}
-
 pub fn assert_trade_state_and_type(
     trade: &Trade,
     offer_type: &OfferType,

--- a/contracts/packages/protocol/src/hub.rs
+++ b/contracts/packages/protocol/src/hub.rs
@@ -41,6 +41,7 @@ pub struct HubConfig {
     pub burn_fee_pct: u128,
     pub chain_fee_pct: u128,
     pub warchest_fee_pct: u128,
+    pub trade_expiration_timer: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/packages/protocol/src/offer.rs
+++ b/contracts/packages/protocol/src/offer.rs
@@ -294,7 +294,6 @@ impl OfferModel<'_> {
 pub struct TradeInfo {
     pub trade: TradeResponse,
     pub offer: OfferResponse,
-    pub expired: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
task: LOCAL-818

- returns `TradeInfo` instead of `Trade` on `fetchTradeDetail`
- adds `expires_at` field in the `Trade` and `TradeResponse`
- adds `trade_expiration_timer` parameter in the hub configs
- shows the add timer on `TradeDetail` and `OpenTrade` components