### PR TITLE
fix: pagination offers

### DIFF
--- a/app/src/network/cosmos/CosmosChain.ts
+++ b/app/src/network/cosmos/CosmosChain.ts
@@ -174,10 +174,8 @@ export class CosmosChain implements Chain {
           fiat_currency: args.fiatCurrency,
           offer_type: args.offerType,
           denom: args.denom,
-          // min: "",
-          // max: "",
-          limit: 10,
           order: args.order,
+          limit: 10,
         },
       }
       const response = (await this.cwClient!.queryContractSmart(

--- a/app/src/network/cosmos/CosmosChain.ts
+++ b/app/src/network/cosmos/CosmosChain.ts
@@ -128,13 +128,14 @@ export class CosmosChain implements Chain {
     }
   }
 
-  async fetchMyOffers() {
+  async fetchMyOffers(limit = 10, last = '') {
     if (this.cwClient instanceof SigningCosmWasmClient) {
       try {
         return (await this.cwClient.queryContractSmart(this.hubInfo.hubConfig.offer_addr, {
           offers_by_owner: {
             owner: this.getWalletAddress(),
-            limit: 10,
+            limit,
+            last,
           },
         })) as OfferResponse[]
       } catch (e) {
@@ -163,7 +164,7 @@ export class CosmosChain implements Chain {
     }
   }
 
-  async fetchOffers(args: FetchOffersArgs) {
+  async fetchOffers(args: FetchOffersArgs, limit = 10, last = '') {
     // TODO: fix init
     if (!this.cwClient) {
       await this.init()
@@ -175,7 +176,8 @@ export class CosmosChain implements Chain {
           offer_type: args.offerType,
           denom: args.denom,
           order: args.order,
-          limit: 10,
+          limit,
+          last,
         },
       }
       const response = (await this.cwClient!.queryContractSmart(

--- a/app/tests/pagination.spec.ts
+++ b/app/tests/pagination.spec.ts
@@ -1,0 +1,72 @@
+import { TextDecoder, TextEncoder } from 'util'
+import { jest } from '@jest/globals'
+import dotenv from 'dotenv'
+import { setupProtocol } from './utils'
+import type { TestCosmosChain } from './network/TestCosmosChain'
+import makerSecrets from './fixtures/maker_secrets.json'
+import { FiatCurrency, OfferOrder, OfferType } from '~/types/components.interface'
+import 'isomorphic-fetch'
+
+dotenv.config()
+Object.assign(global, { TextEncoder, TextDecoder })
+
+const args = {
+  denom: { native: 'ukuji' },
+  fiatCurrency: FiatCurrency.ARS,
+  offerType: OfferType.sell,
+  order: OfferOrder.trades_count,
+}
+const limit = 3
+
+let takerClient: TestCosmosChain
+let makerClient: TestCosmosChain
+jest.setTimeout(60 * 1000)
+beforeAll(async () => {
+  const result = await setupProtocol()
+  takerClient = result.takerClient
+  makerClient = result.makerClient
+})
+
+describe('offers pagination', () => {
+  it(`maker must have at least ${limit} offers`, async () => {
+    let myOffers = await makerClient.fetchMyOffers(limit)
+    if (myOffers.length < limit) {
+      for (let i = 0; i < limit - myOffers.length; i++) {
+        await makerClient.createOffer({
+          denom: args.denom,
+          fiat_currency: args.fiatCurrency,
+          min_amount: '100000',
+          max_amount: '1000000',
+          offer_type: args.offerType,
+          owner_contact: 'maker001',
+          owner_encryption_key: makerSecrets.publicKey,
+          rate: (100 - i).toString(),
+        })
+      }
+      myOffers = await makerClient.fetchMyOffers(limit)
+    }
+    expect(myOffers.length).toBe(limit)
+  })
+  it('maker should be able to paginate the list of offers', async () => {
+    let myOffers = await makerClient.fetchMyOffers(limit)
+    for (let i = 0; i < myOffers.length - 1; i++) {
+      const previousId = myOffers[myOffers.length - 2].offer.id
+      const last = myOffers[myOffers.length - 1].offer.id
+      myOffers = await makerClient.fetchMyOffers(myOffers.length, last)
+      expect(myOffers[myOffers.length - 1].offer.id).toBe(previousId)
+    }
+  })
+  it(`taker should list only ${limit} offers`, async () => {
+    const offers = await takerClient.fetchOffers(args, limit)
+    expect(offers.length).toBe(limit)
+  })
+  it('taker should be able to paginate the list of offers', async () => {
+    let offers = await takerClient.fetchOffers(args, limit)
+    for (let i = 0; i < offers.length - 1; i++) {
+      const previousId = offers[offers.length - 2].offer.id
+      const last = offers[offers.length - 1].offer.id
+      offers = await takerClient.fetchOffers(args, limit, last)
+      expect(offers[offers.length - 1].offer.id).toBe(previousId)
+    }
+  })
+})

--- a/app/tests/sequencer.js
+++ b/app/tests/sequencer.js
@@ -7,12 +7,14 @@ class CustomSequencer extends Sequencer {
     tests.forEach((test) => {
       if (test.path.includes('setup.spec')) {
         sorted[0] = test
-      } else if (test.path.includes('price.spec')) {
+      } else if (test.path.includes('pagination.spec')) {
         sorted[1] = test
-      } else if (test.path.includes('arbitration.spec')) {
+      } else if (test.path.includes('price.spec')) {
         sorted[2] = test
-      } else if (test.path.includes('trade.spec.ts')) {
+      } else if (test.path.includes('arbitration.spec')) {
         sorted[3] = test
+      } else if (test.path.includes('trade.spec.ts')) {
+        sorted[4] = test
       }
     })
     return sorted

--- a/contracts/contracts/offer/src/contract.rs
+++ b/contracts/contracts/offer/src/contract.rs
@@ -72,8 +72,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             limit,
             order,
         )?),
-        QueryMsg::OffersByOwner { owner, limit } => {
-            to_binary(&OfferModel::query_by_owner(deps, owner, limit)?)
+        QueryMsg::OffersByOwner { owner, limit, last } => {
+            to_binary(&OfferModel::query_by_owner(deps, owner, limit, last)?)
         }
     }
 }

--- a/contracts/contracts/offer/src/contract.rs
+++ b/contracts/contracts/offer/src/contract.rs
@@ -58,19 +58,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             offer_type,
             fiat_currency,
             denom,
-            min,
-            max,
             order,
             limit,
+            last,
         } => to_binary(&OfferModel::query_by(
             deps,
             offer_type,
             fiat_currency,
             denom,
-            min,
-            max,
-            limit,
             order,
+            limit,
+            last,
         )?),
         QueryMsg::OffersByOwner { owner, limit, last } => {
             to_binary(&OfferModel::query_by_owner(deps, owner, limit, last)?)


### PR DESCRIPTION
Task: LOCAL-874
Hub: kujira1v9k9tkru4fmey3zgem6emy60j4n97ng66g2s4zjk6nt8g7junp8s3lm50s
Description: 
- Fixes pagination in `offers_by_owner` query
- Fixes pagination in `offers_by` query
- Adds Pagination tests

Obs:
run `yarn test -t 'offers pagination'`